### PR TITLE
docs: Improve Claude instructions for issue handling and PR reviews

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -3,36 +3,57 @@ allowed-tools: Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
 description: Review a pull request
 ---
 
-Perform a comprehensive code review using subagents for key areas:
+Perform a comprehensive code review of PR $ARGUMENTS.
 
+## Step 1: Save the PR diff
+
+BEFORE launching any review agents, save the diff:
+```bash
+gh pr diff $ARGUMENTS > /tmp/pr$ARGUMENTS.diff
+```
+
+## Step 2: Launch review agents
+
+Launch these subagents in parallel:
 - code-quality-reviewer
 - performance-reviewer
 - test-coverage-reviewer
 - documentation-accuracy-reviewer
 - security-code-reviewer
 
-Instruct each to only provide noteworthy feedback. Once they finish, review the feedback and post only the feedback that you also deem noteworthy.
+Instruct each to only provide noteworthy feedback.
 
-Provide feedback using inline comments for specific issues.
-Use top-level comments for general observations or praise.
-Keep feedback concise.
+## Step 3: Post comments
+
+Review agent feedback and post only what you deem noteworthy:
+- Inline comments for specific issues
+- Top-level comments for general observations
+- Keep feedback concise
 
 ## Agent Instructions for Inline Comments
 
-Each agent MUST return issues requiring inline comments in this structured format:
+The PR diff has been saved to `/tmp/pr$ARGUMENTS.diff`. Each agent MUST:
 
-```
-INLINE_COMMENT:
-- file: <path>
-- position: <calculated position in diff>
-- comment: <the comment text>
-```
+1. **Read the diff first** - Use `Read` tool on `/tmp/pr$ARGUMENTS.diff`
 
-To calculate position:
-1. The diff hunk header (@@) line is position 1
-2. Count lines from there to the target line
-3. Position = target_line_in_diff - hunk_header_line + 1
+2. **For each issue requiring an inline comment**, calculate the position:
+   - Find the file's `@@` hunk header line number in the diff (use `grep -n "@@"`)
+   - Find your target line number in the diff
+   - Position = target_line_number - hunk_header_line_number + 1
 
-Agents should save the PR diff at the start of their analysis and reference it when identifying issues. This eliminates the need for position lookups after agents complete.
+3. **Return in this exact format** (positions are REQUIRED):
+   ```
+   INLINE_COMMENT:
+   - file: src/example/file.py
+   - position: 42
+   - comment: Your comment text here
+   ```
+
+**Example calculation:**
+- File's `@@` line is at diff line 185
+- Target code is at diff line 210
+- Position = 210 - 185 + 1 = 26
+
+Comments without calculated positions will be discarded.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,19 +140,30 @@ Keep replies concise - briefly state what was changed and reference the commit i
 
 ## Issue Numbering Convention
 
-This project uses **LIR-prefixed identifiers** to distinguish implementation plan items from GitHub issue numbers:
+**CRITICAL:** This project uses **LIR-prefixed identifiers** to distinguish implementation plan items from GitHub issue numbers. These are NOT the same:
 
-- **LIR-N**: Implementation plan item number (e.g., "LIR-4" for Five-Card Hand Evaluation)
-- **GitHub #N**: The actual GitHub issue number (e.g., GitHub #7)
+- **LIR-N**: Implementation plan item number (e.g., "LIR-15" for Custom Strategy Configuration)
+- **GitHub #N**: The actual GitHub issue number (e.g., GitHub #15 might be a completely different issue)
 
-GitHub issue titles use the format `LIR-N: Title` (e.g., "LIR-4: Five-Card Hand Evaluation").
+GitHub issue titles use the format `LIR-N: Title` (e.g., "LIR-12: Custom Strategy Configuration Parser").
+
+### When the user requests work on an issue:
+
+1. **If user says "LIR-N"**: Look up the GitHub issue by searching for the title prefix `LIR-N:` using `gh issue list --search "LIR-N in:title"`. Do NOT assume GitHub issue #N is the same as LIR-N.
+
+2. **If user says "issue N" or "#N"**: Clarify whether they mean LIR-N (implementation plan) or GitHub #N (GitHub issue number).
+
+3. **Always verify**: Before starting work, confirm you have the correct issue by checking the title contains the expected LIR identifier.
+
+### Example:
+- User says: "Work on LIR-15"
+- Correct action: `gh issue list --search "LIR-15 in:title"` to find the GitHub issue
+- WRONG action: Assuming GitHub issue #15 is what they want
 
 When referencing issues:
 - Use `LIR-4` when discussing the implementation plan item
 - Use `GitHub #7` when discussing the GitHub issue itself
 - Use `LIR-4 (GitHub #7)` when both contexts are relevant
-
-This convention prevents confusion between plan numbers and GitHub's auto-assigned issue numbers.
 
 ## Scratchpads
 


### PR DESCRIPTION
## Summary

- Strengthens LIR vs GitHub issue number disambiguation in CLAUDE.md
- Improves review-pr.md to require position calculation during agent analysis

## Problem

When asked to work on "LIR-15" (Bankroll Tracker, GitHub #18), I incorrectly worked on GitHub #15 (which is LIR-12: Custom Strategy Configuration Parser). The existing instructions weren't strong enough to prevent this confusion.

## Changes

**CLAUDE.md:**
- Added explicit steps for looking up LIR-N issues using `gh issue list --search`
- Added warning against assuming GitHub issue #N equals LIR-N
- Added concrete example showing correct vs wrong approach

**review-pr.md:**
- Added explicit step to save PR diff BEFORE launching agents
- Require agents to read diff and calculate positions during analysis
- Added concrete position calculation example
- State that comments without positions will be discarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)