### PR TITLE
chore: Add ruff format step to /issue command workflow

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -39,7 +39,10 @@ Please analyze and fix the GitHub issue: $ARGUMENTS.
    - Positive tests (verify correct behavior)
    - Negative tests (verify error handling)
 3. Run the full test suite: `poetry run pytest`
-4. Ensure linting passes: `poetry run ruff check src/ tests/`
+4. Format and lint code:
+   - Run `poetry run ruff format src/ tests/` to auto-format
+   - Run `poetry run ruff check src/ tests/ --fix` to auto-fix lint issues
+   - If any files were modified, stage and amend the previous commit
 5. Ensure type checking passes: `poetry run mypy src/`
 6. All functions must have type annotations for parameters and return values
 7. Launch **test-coverage-reviewer agent** for coverage verification


### PR DESCRIPTION
## Summary
- Add `ruff format` auto-formatting step to the `/issue` command workflow
- Add `--fix` flag to `ruff check` for automatic lint fixes
- Prevent formatting issues from slipping through to separate cleanup PRs

## Problem
The `/issue` command was only running `ruff check` (linting) but not `ruff format` (formatting). This caused code style inconsistencies that required separate cleanup PRs (e.g., PR #83).

## Solution
Updated the TEST section to:
1. Run `ruff format src/ tests/` to auto-format before committing
2. Run `ruff check src/ tests/ --fix` to auto-fix lint issues
3. Amend commits if formatting modifies any files

## Test plan
- [ ] Run `/issue` on a test issue and verify formatting is applied
- [ ] Confirm no manual formatting cleanup is needed after PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)