### PR TITLE
feat: Add /merge-pr command for PR merge and branch cleanup

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -1,0 +1,23 @@
+---
+description: Merge a PR and clean up branches
+---
+
+Merge PR $ARGUMENTS and clean up associated branches.
+
+```bash
+# Merge the PR (squash merge)
+gh pr merge $ARGUMENTS --squash --delete-branch
+
+# Switch to main and pull latest
+git checkout main
+git pull origin main
+
+# Delete the local branch if it exists
+PR_BRANCH=$(gh pr view $ARGUMENTS --json headRefName -q '.headRefName')
+git branch -d "$PR_BRANCH" 2>/dev/null || echo "Local branch already deleted or not found"
+
+# Prune any other stale remote tracking branches
+git fetch --prune origin
+```
+
+Report the merge status and confirm cleanup.


### PR DESCRIPTION
## Summary

Adds a new `/merge-pr` slash command that automates the PR merge and branch cleanup workflow.

## What it does

1. Squash merges the PR via `gh pr merge --squash --delete-branch`
2. Switches to main and pulls latest
3. Deletes the local branch if it exists
4. Prunes any stale remote tracking branches

## Usage

```
/merge-pr 123
```

## Test plan

- [ ] Create a test PR
- [ ] Run `/merge-pr <pr-number>`
- [ ] Verify PR is merged, remote branch deleted, local branch deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)