### PR TITLE
feat: Add command metrics logging system for continuous improvement

### DIFF
--- a/.claude/commands/analyze-metrics.md
+++ b/.claude/commands/analyze-metrics.md
@@ -1,0 +1,219 @@
+---
+description: Analyze command metrics and propose improvements
+---
+
+Analyze collected command metrics and generate an effectiveness report.
+
+## Step 1: Load Metrics Data
+
+Read the metrics log:
+```bash
+cat .claude/metrics/command_log.jsonl 2>/dev/null || echo "NO_METRICS_FILE"
+```
+
+If the file does not exist or is empty, report:
+> No metrics have been collected yet. Run some commands (e.g., `/review-pr`, `/issue`, `/merge-pr`) and they will automatically log metrics.
+
+Then exit.
+
+## Step 2: Parse and Calculate Statistics
+
+For each command type found in the log, calculate:
+
+### Execution Metrics
+- Total executions
+- Success rate: `success / total`
+- Partial success rate: `partial_success / total`
+- Failure rate: `failure / total`
+- Abort rate: `aborted / total`
+- Average steps completed vs total
+- Average tool calls per execution
+- Duration distribution by bracket
+
+### Clarification Analysis
+- Total clarifications required across all executions
+- Clarification rate: `clarifications / executions`
+- Most common clarification types (ranked by frequency)
+
+## Step 3: Identify Patterns
+
+Analyze the `observations` fields across all entries:
+
+### Recurring Issues (High Priority)
+- Errors that appear in multiple executions
+- Warnings that repeat across runs
+- Edge cases hit frequently (3+ occurrences)
+
+### Prompt Improvement Signals
+- Ambiguities mentioned more than once → unclear instructions
+- Missing instructions cited repeatedly → gaps in command docs
+- Improvement suggestions that recur → validated enhancement ideas
+
+### Command-Specific Insights
+- Which commands have lowest success rates?
+- Which commands require most user clarifications?
+- Which commands take longest (by duration bracket)?
+- Which commands have highest tool call counts?
+
+## Step 4: Generate Report
+
+Create a report at `.claude/metrics/analysis_reports/`:
+```bash
+mkdir -p .claude/metrics/analysis_reports
+```
+
+File name: `{YYYY-MM-DD}_analysis.md`
+
+### Report Structure
+
+```markdown
+# Command Metrics Analysis Report
+
+**Generated:** {timestamp}
+**Period:** {earliest_entry_date} to {latest_entry_date}
+**Total Executions:** {count}
+
+## Executive Summary
+
+[2-3 sentences highlighting the most important findings]
+
+## Command Performance
+
+### /review-pr
+- Executions: X
+- Success Rate: X%
+- Avg Tool Calls: X
+- Avg Duration: X
+- Clarification Rate: X%
+
+[Repeat for each command type found]
+
+## Recurring Patterns
+
+### Most Common Clarification Types
+| Rank | Type | Count | % of Clarifications |
+|------|------|-------|---------------------|
+| 1 | {type} | {n} | {pct}% |
+
+### Frequently Hit Edge Cases
+| Count | Edge Case | Command(s) |
+|-------|-----------|------------|
+| {n} | {description} | {commands} |
+
+### Repeated Errors
+| Count | Error | Command(s) |
+|-------|-------|------------|
+| {n} | {error} | {commands} |
+
+### Repeated Warnings
+| Count | Warning | Command(s) |
+|-------|---------|------------|
+| {n} | {warning} | {commands} |
+
+## Improvement Recommendations
+
+### High Priority (Recurring Issues)
+
+For each recommendation:
+1. **{Command}**: {Specific recommendation}
+   - Evidence: {X occurrences of Y}
+   - Impact: {What improves if fixed}
+
+### Medium Priority (Optimization)
+[List recommendations with evidence]
+
+### Low Priority (Enhancement)
+[List suggestions from improvement_suggestions field]
+
+## Proposed Edits
+
+For each high-priority recommendation where a specific edit can be proposed:
+
+### Proposal {N}: {Title}
+
+**File:** `.claude/commands/{command}.md`
+**Section:** {Section name or line range}
+
+**Problem:** {What the data shows}
+
+**Current text:**
+```
+[existing text from command file]
+```
+
+**Proposed text:**
+```
+[improved text]
+```
+
+**Rationale:** {Why this change addresses the identified pattern}
+```
+
+## Step 5: Present Findings
+
+Display the full report to the console.
+
+If there are high-priority recommendations with proposed edits, use AskUserQuestion:
+
+**Question:** "Would you like me to apply the proposed command improvements?"
+
+**Options:**
+- A) Apply all high-priority edits
+- B) Review each edit individually
+- C) Save report only, no edits
+
+## Step 6: Apply Edits (if requested)
+
+### If user selects A (Apply all):
+1. For each proposed edit, modify the target command file
+2. Commit all changes together
+
+### If user selects B (Review individually):
+1. For each proposed edit, show the before/after and ask:
+   - "Apply this edit to {file}?" [Yes / No / Modify]
+2. Apply approved edits
+3. Commit approved changes
+
+### Commit format:
+```bash
+git add .claude/commands/ .claude/metrics/analysis_reports/
+git commit -m "refactor: Improve command files based on metrics analysis
+
+Applied recommendations from metrics analysis.
+Analysis period: {start} to {end} ({N} executions)
+
+Changes:
+- {list of applied changes}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+## Step 7: Archive Metrics (Optional)
+
+After generating the report, use AskUserQuestion:
+
+**Question:** "Archive processed metrics to start fresh data collection?"
+
+**Options:**
+- Yes - Move log to archive, start fresh
+- No - Keep accumulating data
+
+### If Yes:
+```bash
+mkdir -p .claude/metrics/archive
+mv .claude/metrics/command_log.jsonl .claude/metrics/archive/command_log_$(date +%Y-%m-%d).jsonl
+```
+
+---
+
+## METRICS LOGGING (Required)
+
+Before presenting the final outcome, log metrics per `.claude/memories/metrics-logging-protocol.md`:
+
+1. Ensure `.claude/metrics/` directory exists
+2. Construct the metrics JSON reflecting this execution (command name: "analyze-metrics", steps_total: 7)
+3. Append to `.claude/metrics/command_log.jsonl`
+
+Pay special attention to the `observations` fields - these drive continuous improvement.

--- a/.claude/commands/fix-review.md
+++ b/.claude/commands/fix-review.md
@@ -223,3 +223,15 @@ Then display the same summary to the console for the user.
 - Don't silently skip issues - either fix them or explicitly defer with user consent
 - For "B) Create issue": always update `docs/implementation_todo.md`
 - Reply to ALL @claude PR comments after fixing
+
+---
+
+## METRICS LOGGING (Required)
+
+Before presenting the final outcome, log metrics per `.claude/memories/metrics-logging-protocol.md`:
+
+1. Ensure `.claude/metrics/` directory exists
+2. Construct the metrics JSON reflecting this execution (command name: "fix-review", steps_total: 8 - SETUP/GATHER/BUILD-MATRIX/CONSOLIDATE/TODO/IMPLEMENT/VALIDATE/DEFERRED/SUMMARY)
+3. Append to `.claude/metrics/command_log.jsonl`
+
+Pay special attention to the `observations` fields - these drive continuous improvement.

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -59,3 +59,15 @@ Before creating the PR, launch the **code-quality-reviewer agent** to check your
    - Title: `{feat|fix}: LIR-N description`
    - Body must include: `Closes #{github_issue_number}`
 3. Note the PR number for `/review-pr`
+
+---
+
+## METRICS LOGGING (Required)
+
+Before presenting the final outcome, log metrics per `.claude/memories/metrics-logging-protocol.md`:
+
+1. Ensure `.claude/metrics/` directory exists
+2. Construct the metrics JSON reflecting this execution (command name: "issue", steps_total: 6 - IDENTIFY/PLAN/CREATE/TEST/VERIFY/PUSH)
+3. Append to `.claude/metrics/command_log.jsonl`
+
+Pay special attention to the `observations` fields - these drive continuous improvement.

--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -21,3 +21,15 @@ git fetch --prune origin
 ```
 
 Report the merge status and confirm cleanup.
+
+---
+
+## METRICS LOGGING (Required)
+
+Before presenting the final outcome, log metrics per `.claude/memories/metrics-logging-protocol.md`:
+
+1. Ensure `.claude/metrics/` directory exists
+2. Construct the metrics JSON reflecting this execution (command name: "merge-pr", steps_total: 4 - merge/checkout/delete-local/prune)
+3. Append to `.claude/metrics/command_log.jsonl`
+
+Pay special attention to the `observations` fields - these drive continuous improvement.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -95,3 +95,15 @@ The PR diff has been saved to `/tmp/pr$ARGUMENTS.diff`. Each agent MUST:
    - Summary (2-3 sentences)
    - Findings by severity (Critical/High/Medium/Low)
    - Specific recommendations with file:line references
+
+---
+
+## METRICS LOGGING (Required)
+
+Before presenting the final outcome, log metrics per `.claude/memories/metrics-logging-protocol.md`:
+
+1. Ensure `.claude/metrics/` directory exists
+2. Construct the metrics JSON reflecting this execution (command name: "review-pr", steps_total: 5)
+3. Append to `.claude/metrics/command_log.jsonl`
+
+Pay special attention to the `observations` fields - these drive continuous improvement.

--- a/.claude/memories/metrics-logging-protocol.md
+++ b/.claude/memories/metrics-logging-protocol.md
@@ -1,0 +1,99 @@
+# Metrics Logging Protocol
+
+This protocol defines how to log metrics at the end of every slash command execution. These metrics enable continuous improvement of command effectiveness.
+
+## When to Log
+
+Log metrics as the **FINAL step** of every command, immediately before presenting the final summary to the user. Log even on failure - failure data is especially valuable.
+
+## How to Log
+
+1. Create the metrics directory if it does not exist:
+   ```bash
+   mkdir -p .claude/metrics
+   ```
+
+2. Construct a single-line JSON object following the schema below
+
+3. Append to the log file:
+   ```bash
+   echo '{"timestamp":"...","command":{...},...}' >> .claude/metrics/command_log.jsonl
+   ```
+
+## Schema
+
+### timestamp (required)
+ISO 8601 format: `2025-12-08T14:32:15Z`
+
+### command (required)
+- `name`: Command name without slash (e.g., "review-pr", "issue", "merge-pr", "fix-review")
+- `arguments`: Raw arguments exactly as passed
+
+### context
+- `branch`: Current git branch (`git branch --show-current`)
+- `repo_state`: One of "clean", "dirty", "untracked", "staged"
+- `related_pr`: PR number if applicable, otherwise null
+- `related_issue`: Issue identifier if applicable (e.g., "LIR-15" or "#42"), otherwise null
+
+### outcome (required)
+- `status`: One of:
+  - `success`: All steps completed successfully
+  - `partial_success`: Main goal achieved but with skipped/failed substeps
+  - `failure`: Could not complete the main objective
+  - `aborted`: User cancelled or command was interrupted
+- `failure_reason`: Brief explanation if not success, otherwise null
+
+### metrics
+- `steps_completed`: Count of major steps finished
+- `steps_total`: Expected steps per the command definition
+- `tool_calls`: Approximate number of tool invocations
+- `clarifications_required`: Times you asked the user for clarification
+- `duration_estimate`: One of "<1min", "1-5min", "5-15min", ">15min"
+
+### observations (most important for improvement)
+
+Reflect honestly on the execution:
+
+- `clarification_types`: Array of categories when clarification was needed:
+  - `ambiguous_argument`: Argument meaning was unclear
+  - `missing_context`: Needed information not provided
+  - `conflicting_instructions`: Command instructions contradicted each other
+  - `external_dependency`: Blocked by external system/API
+  - `permission_issue`: Lacked necessary permissions
+  - `unexpected_state`: Repo/PR/issue in unexpected state
+  - `scope_clarification`: Unclear what was in/out of scope
+  - `other`: Doesn't fit other categories
+
+- `edge_cases_hit`: Array of unexpected scenarios that needed handling (e.g., "branch already deleted", "PR already merged", "no changes to commit")
+
+- `errors`: Array of error messages encountered
+
+- `warnings`: Array of non-fatal issues
+
+- `ambiguities`: Array of instructions in the command file that were unclear or could be interpreted multiple ways
+
+- `missing_instructions`: Array of steps you had to improvise that should be documented in the command file
+
+- `improvement_suggestions`: Array of ideas to make the command better
+
+## Example Log Entry
+
+After completing `/merge-pr 108`:
+
+```json
+{"timestamp":"2025-12-08T14:32:15Z","command":{"name":"merge-pr","arguments":"108"},"context":{"branch":"main","repo_state":"clean","related_pr":108,"related_issue":null},"outcome":{"status":"success","failure_reason":null},"metrics":{"steps_completed":4,"steps_total":4,"tool_calls":4,"clarifications_required":0,"duration_estimate":"<1min"},"observations":{"clarification_types":[],"edge_cases_hit":["local branch already deleted"],"errors":[],"warnings":[],"ambiguities":[],"missing_instructions":[],"improvement_suggestions":[]}}
+```
+
+After a `/review-pr` with issues:
+
+```json
+{"timestamp":"2025-12-08T15:45:00Z","command":{"name":"review-pr","arguments":"112"},"context":{"branch":"main","repo_state":"clean","related_pr":112,"related_issue":"LIR-25"},"outcome":{"status":"partial_success","failure_reason":"security-reviewer agent timed out"},"metrics":{"steps_completed":4,"steps_total":5,"tool_calls":28,"clarifications_required":1,"duration_estimate":"5-15min"},"observations":{"clarification_types":["scope_clarification"],"edge_cases_hit":[],"errors":["Agent security-code-reviewer exceeded timeout"],"warnings":["Large diff (2000+ lines) may have impacted review quality"],"ambiguities":["Unclear whether to review test files"],"missing_instructions":["No guidance on handling agent timeouts"],"improvement_suggestions":["Add timeout handling with retry logic","Specify test file review policy"]}}
+```
+
+## Critical Reminders
+
+- **Always log** - Even failures and aborts produce valuable data
+- **Be honest** - Observations drive real improvements; don't minimize issues
+- **Single line** - Keep JSON on one line (JSONL format)
+- **Escape carefully** - Use proper JSON escaping for quotes and special characters in strings
+- **Don't skip** - Logging is mandatory for all command executions

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ __marimo__/
 
 # macOS
 .DS_Store
+
+# Claude Code metrics (local to user)
+.claude/metrics/


### PR DESCRIPTION
## Summary

- Adds a metrics logging system for Claude Code slash commands to enable continuous improvement
- Creates `/analyze-metrics` command to review collected data and propose command improvements
- Instruments all existing commands to automatically log execution metrics

## Changes

**New files:**
- `.claude/memories/metrics-logging-protocol.md` - Defines JSON schema and logging procedure
- `.claude/commands/analyze-metrics.md` - Analysis command for reviewing metrics

**Modified files:**
- `.claude/commands/review-pr.md` - Added metrics logging section
- `.claude/commands/issue.md` - Added metrics logging section
- `.claude/commands/merge-pr.md` - Added metrics logging section
- `.claude/commands/fix-review.md` - Added metrics logging section
- `.gitignore` - Added `.claude/metrics/` exclusion (logs stay local)

## Metrics Captured

Each command execution logs:
- Outcome status (success/partial_success/failure/aborted)
- Tool call count and duration estimate
- Clarifications required and their types
- Edge cases hit, errors, and warnings
- Ambiguities in command instructions
- Missing instructions discovered
- Improvement suggestions

## How It Works

1. Commands log metrics to `.claude/metrics/command_log.jsonl` (JSONL format, gitignored)
2. Run `/analyze-metrics` periodically to review patterns
3. Analysis generates a report with statistics and proposed edits
4. User can approve/reject proposed command improvements

## Test plan

- [ ] Run `/merge-pr` on a test PR and verify metrics are logged
- [ ] Run `/analyze-metrics` to verify it reads logs and generates report
- [ ] Verify `.claude/metrics/` is properly gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)