### PR TITLE
chore: Optimize Claude Code config for token efficiency

### DIFF
--- a/.claude/commands/fix-review.md
+++ b/.claude/commands/fix-review.md
@@ -20,12 +20,7 @@ Also add any @claude PR comments as High severity issues (record comment ID for 
 
 # BUILD ISSUE MATRIX
 
-Before implementing fixes, create a matrix of ALL issues:
-
-| # | Reviewer | Severity | Issue | File:Line | In PR Scope? | Actionable? |
-|---|----------|----------|-------|-----------|--------------|-------------|
-
-**Actionable** = Can fix without adding dependencies, changing files outside PR, or major refactoring.
+Before implementing fixes, create a matrix of ALL issues using format from `.claude/memories/review-issue-matrix.md`.
 
 # CREATE TODO LIST
 

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -3,86 +3,43 @@ allowed-tools: Bash(gh issue view:*),Bash(gh issue list:*),Bash(git checkout:*),
 description: Analyze and fix a GitHub issue
 ---
 
-Please analyze and fix the GitHub issue: $ARGUMENTS.
+Analyze and fix GitHub issue: $ARGUMENTS
 
-# IDENTIFY THE ISSUE
+## 1. IDENTIFY & APPROVE
 
-## MANDATORY USER APPROVAL CHECKPOINT
+**Required before ANY work:**
+1. Find issue:
+   - "next": Check `docs/implementation_todo.md` + `gh issue list --state open`
+   - "LIR-N": `gh issue list --search "LIR-N in:title"`
+   - Number: `gh issue view $ARGUMENTS`
+2. **Use AskUserQuestion** for approval (GitHub #, LIR-N, title, description)
+3. Only proceed after explicit "Yes"
 
-**STOP! Before doing ANY work, you MUST get explicit user approval for the issue.**
+## 2. PLAN
 
-This applies to ALL cases - "next", LIR identifiers, and issue numbers.
+1. `gh issue view` for full details
+2. Launch **Explore agent** (medium) for complex issues - check `/scratchpads/`, closed PRs, patterns
+3. Break into tasks with **TodoWrite**
+4. Create scratchpad: `/scratchpads/issue-{number}-{short-name}.md` with issue link + tasks
 
-1. First, identify the issue:
-   - **If "next":** Read `docs/implementation_todo.md` and `gh issue list --state open` to find the next issue
-   - **If "LIR-N" format:** `gh issue list --search "LIR-N in:title"` to find the GitHub issue
-   - **If a number:** `gh issue view $ARGUMENTS` directly
+## 3. CREATE
 
-2. **THEN IMMEDIATELY USE AskUserQuestion** to get approval:
-   - Present: GitHub issue number, LIR identifier, title, and brief description
-   - Ask: "Should I proceed with this issue?"
-   - Options: "Yes, proceed" / "No, choose different issue"
-   - **DO NOT SKIP THIS STEP. DO NOT PROCEED WITHOUT USER CONFIRMATION.**
+1. Create branch: `feature/issue-{number}-{desc}` or `fix/issue-{number}-{desc}`
+2. Stage scratchpad: `git add scratchpads/issue-{number}-*.md`
+3. Implement in small steps, commit after each
+4. Include scratchpad in first commit
 
-3. If user declines, ask which issue they prefer and repeat step 2
+## 4. TEST
 
-4. Only after explicit "Yes" confirmation, proceed to the PLAN phase
+1. Write positive + negative tests
+2. Run: `poetry run pytest`
+3. Format/lint: `poetry run ruff format src/ tests/ && poetry run ruff check src/ tests/ --fix`
+4. Type check: `poetry run mypy src/`
+5. All functions need type annotations
+6. Launch **test-coverage-reviewer agent**
 
-# PLAN
+## 5. VERIFY & PUSH
 
-1. Use `gh issue view` to get full issue details
-2. For complex issues, launch an **Explore agent** (thoroughness: medium) to understand context:
-   - Search `/scratchpads/` for previous thoughts on this issue
-   - Search closed PRs for related history
-   - Find relevant source files and existing patterns
-3. Ask clarifying questions if the issue is ambiguous
-4. Break the issue into small, manageable tasks using the **TodoWrite tool**
-5. For complex architectural decisions, use the **Plan agent**
-6. Document your plan in a scratchpad: `/scratchpads/issue-{number}-{short-name}.md`
-   - Include link to the GitHub issue
-   - List the planned tasks
-
-# CREATE
-
-**CHECKPOINT:** Before writing any code, verify the scratchpad exists:
-- File: `/scratchpads/issue-{number}-{short-name}.md`
-- Must contain: GitHub issue link, planned tasks
-- If missing, create it now before proceeding
-
-1. Create branch: `feature/issue-{number}-{short-description}` or `fix/issue-{number}-...`
-2. **Stage the scratchpad immediately** after creating the branch:
-   ```bash
-   git add scratchpads/issue-{number}-{short-name}.md
-   ```
-3. Implement in small steps according to your plan
-4. Commit after each logical step with descriptive messages
-5. **Include the scratchpad in your first commit** - it documents the planning process
-
-# TEST
-
-1. Check the issue for specified test requirements
-2. Write tests:
-   - Positive tests (verify correct behavior)
-   - Negative tests (verify error handling)
-3. Run the full test suite: `poetry run pytest`
-4. Format and lint code:
-   ```bash
-   poetry run ruff format src/ tests/ && poetry run ruff check src/ tests/ --fix
-   ```
-   If any files were modified, stage and amend the previous commit
-5. Ensure type checking passes: `poetry run mypy src/`
-6. All functions must have type annotations for parameters and return values
-7. Launch **test-coverage-reviewer agent** for coverage verification
-
-# VERIFY
-
-Before creating the PR, launch the **code-quality-reviewer agent** to check your implementation.
-
-# PUSH
-
-1. Push branch: `git push -u origin {branch-name}`
-2. Create PR with `gh pr create`:
-   - Title: `{feat|fix}: LIR-N description`
-   - Body must include: `Closes #{github_issue_number}`
-3. Note the PR number for `/review-pr`
-
+1. Launch **code-quality-reviewer agent**
+2. Push: `git push -u origin {branch}`
+3. Create PR: `gh pr create` with title `{feat|fix}: LIR-N description`, body includes `Closes #{github_issue_number}`

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -37,8 +37,7 @@ After agents complete, create `CONSOLIDATED-REVIEW.md`:
 [2-3 sentences]
 
 ## Issue Matrix
-| # | Severity | Issue | File:Line | Reviewer(s) | In PR Scope? | Actionable? |
-|---|----------|-------|-----------|-------------|--------------|-------------|
+(Use format from `.claude/memories/review-issue-matrix.md`)
 
 ## Actionable Issues
 [Issues where In PR Scope AND Actionable are Yes]
@@ -46,8 +45,6 @@ After agents complete, create `CONSOLIDATED-REVIEW.md`:
 ## Deferred Issues
 [Issues where either is No, with reason]
 ```
-
-**Severity levels:** Critical (security/data loss), High (>10% perf impact, missing tests), Medium (maintainability), Low (skip).
 
 ## Step 4: Post Comment
 

--- a/.claude/memories/github-cli-pr-comments.md
+++ b/.claude/memories/github-cli-pr-comments.md
@@ -1,0 +1,38 @@
+# GitHub CLI: PR Inline Comments
+
+## Posting Inline Comments
+
+Use `position` (integer) not `line` or `subject_type`. Position is the line number **within the diff hunk**, not the file line number.
+
+**Calculate position:**
+1. `gh pr diff PR_NUMBER > /tmp/pr.diff`
+2. Find `@@` hunk header line number for target file
+3. `position = target_line_in_diff - hunk_header_line`
+
+**Example:** `@@` at line 182, target at line 223 → position = `223 - 181 = 42` (the @@ line is position 1)
+
+```bash
+# Find position
+gh pr diff PR_NUMBER > /tmp/pr.diff
+cat -n /tmp/pr.diff | grep -A 5 "code to comment on"
+
+# Post comment (use -F for integer)
+gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments \
+  --method POST \
+  -f body="Comment" \
+  -f path="path/to/file.py" \
+  -f commit_id="$(gh pr view PR_NUMBER --json headRefOid -q .headRefOid)" \
+  -F position=42
+```
+
+## Responding to PR Comments
+
+```bash
+# Find comment ID
+gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments --jq '.[] | {id, body: .body[:50]}'
+
+# Reply
+gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments/COMMENT_ID/replies \
+  --method POST \
+  -f body="Done. Updated X to do Y."
+```

--- a/.claude/memories/review-issue-matrix.md
+++ b/.claude/memories/review-issue-matrix.md
@@ -1,0 +1,25 @@
+# Code Review Issue Matrix Format
+
+## Standard Matrix
+
+| # | Severity | Issue | File:Line | Reviewer(s) | In PR Scope? | Actionable? |
+|---|----------|-------|-----------|-------------|--------------|-------------|
+
+## Severity Levels
+
+- **Critical**: Security vulnerabilities, data loss risks
+- **High**: >10% performance impact, missing tests for new code
+- **Medium**: Maintainability, code quality issues
+- **Low**: Minor style issues (auto-skip)
+
+## Actionability Criteria
+
+**Actionable = Yes** when ALL true:
+- No new dependencies needed
+- Changes stay within PR's modified files
+- No major refactoring required
+
+**Actionable = No** examples:
+- Requires changes to files not in PR
+- Would need new library/dependency
+- Architectural changes beyond scope

--- a/.claude/references/let-it-ride-game-rules.md
+++ b/.claude/references/let-it-ride-game-rules.md
@@ -1,0 +1,46 @@
+# Let It Ride - Game Rules
+
+## Main Game Flow
+
+1. Player places 3 equal bets (Bet 1, Bet 2, Bet 3)
+2. Player receives 3 cards face-down
+3. **Decision 1**: After viewing 3 cards, pull Bet 1 back OR let it ride
+4. First community card revealed (4 cards now visible)
+5. **Decision 2**: Pull Bet 2 back OR let it ride
+6. Second community card revealed (5 cards total)
+7. Final hand evaluated - pays per paytable on remaining bets
+
+## Standard Paytable
+
+| Hand | Payout |
+|------|--------|
+| Royal Flush | 1000:1 |
+| Straight Flush | 200:1 |
+| Four of a Kind | 50:1 |
+| Full House | 11:1 |
+| Flush | 8:1 |
+| Straight | 5:1 |
+| Three of a Kind | 3:1 |
+| Two Pair | 2:1 |
+| Pair (10s or better) | 1:1 |
+| Other | Loss |
+
+## Three Card Bonus (Optional Side Bet)
+
+Separate bet on player's initial 3 cards only:
+
+| Hand | Payout |
+|------|--------|
+| Mini Royal (A-K-Q suited) | 50:1 |
+| Straight Flush | 40:1 |
+| Three of a Kind | 30:1 |
+| Straight | 6:1 |
+| Flush | 3:1 |
+| Pair | 1:1 |
+
+## Key Strategic Points
+
+- Minimum paying hand is pair of 10s or better
+- Basic strategy: Let it ride with made hands or strong draws
+- Community cards are shared - same for all players at table
+- House edge ~3.5% with basic strategy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,14 +59,9 @@ Key abstractions:
 - `TableSession`: manages multi-seat table sessions with per-seat tracking
 - `DealerConfig`: optional dealer discard (burn cards) before community cards
 
-## Game Rules Summary
+## Game Rules
 
-1. Player places 3 equal bets, receives 3 cards
-2. **Decision 1**: After viewing 3 cards, pull Bet 1 or let it ride
-3. First community card revealed (4 cards visible)
-4. **Decision 2**: Pull Bet 2 or let it ride
-5. Second community card revealed, hands pay per paytable
-6. Optional Three Card Bonus: side bet on player's initial 3 cards
+Let It Ride: 3 equal bets, 3 player cards, 2 community cards. Two decision points to pull bets or let them ride. Pays on pair of 10s+. See `.claude/references/let-it-ride-game-rules.md` for full rules and paytables.
 
 ## Configuration
 
@@ -96,59 +91,7 @@ The `RNGManager` class provides centralized seed management for reproducible sim
 
 ## GitHub CLI Tips
 
-### Posting PR Inline Comments
-
-Use `position` (integer) not `line` or `subject_type`. The position is the line number **within the diff hunk**, not the file line number.
-
-**Calculating the correct position:**
-
-1. Save the PR diff: `gh pr diff PR_NUMBER > /tmp/pr.diff`
-2. Find where the target file's diff starts (look for `diff --git a/path/to/file`)
-3. Find the `@@` hunk header line number in the combined diff
-4. Calculate: `position = target_line_in_diff - hunk_header_line`
-
-**Example:** If a file's `@@` line is at line 182 in the diff, and you want to comment on what appears at line 223, the position is `223 - 181 = 42` (the @@ line itself is position 1).
-
-```bash
-# First, examine the diff to find correct positions
-gh pr diff PR_NUMBER > /tmp/pr.diff
-cat -n /tmp/pr.diff | grep -A 5 "the code you want to comment on"
-
-# Then post with the calculated position
-gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments \
-  --method POST \
-  -f body="Comment text" \
-  -f path="path/to/file.py" \
-  -f commit_id="$(gh pr view PR_NUMBER --json headRefOid -q .headRefOid)" \
-  -F position=42
-```
-
-**Important:**
-- Use `-F position=42` (capital F) to pass as integer, not `-f position=42` (string)
-- The position is relative to the diff hunk, NOT the absolute file line number
-- Always verify positions by examining the actual diff output before posting comments
-
-### Responding to PR Review Comments
-
-When making changes in response to a PR review comment (especially those tagged with `@claude`):
-
-1. Make the requested code changes
-2. **Reply to the original comment** explaining what was changed
-3. Commit and push the changes
-
-To reply to an inline comment:
-
-```bash
-# Find the comment ID
-gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments --jq '.[] | {id, body: .body[:50]}'
-
-# Reply to the comment
-gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments/COMMENT_ID/replies \
-  --method POST \
-  -f body="Done. Updated X to do Y. See commit abc123."
-```
-
-Keep replies concise - briefly state what was changed and reference the commit if helpful.
+For PR inline comments, use `position` (diff line offset from `@@` header), not `line`. Use `-F` for integer values. See `.claude/memories/github-cli-pr-comments.md` for detailed syntax and examples.
 
 ## Issue Numbering Convention
 


### PR DESCRIPTION
## Summary

- Move GitHub CLI PR comment syntax from CLAUDE.md to `.claude/memories/github-cli-pr-comments.md`
- Move game rules and paytables to `.claude/references/let-it-ride-game-rules.md`
- Extract review issue matrix format to shared `.claude/memories/review-issue-matrix.md`
- Condense `issue.md` command from 89 to 45 lines (49% reduction)
- Reduce `CLAUDE.md` from 182 to 125 lines (31% reduction)

Reference material now loads on-demand rather than every conversation, reducing baseline token usage by ~1,000-1,500 tokens per session.

## Test plan

- [ ] Verify `/issue` command still works correctly
- [ ] Verify `/review-pr` command still works correctly
- [ ] Verify `/fix-review` command still works correctly
- [ ] Confirm memory files are accessible when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)