### PR TITLE
chore: Optimize /issue command for token efficiency

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -18,9 +18,12 @@ Analyze and fix GitHub issue: $ARGUMENTS
 ## 2. PLAN
 
 1. `gh issue view` for full details
-2. Launch **Explore agent** (medium) for complex issues - check `/scratchpads/`, closed PRs, patterns
+2. For complex issues, launch **Explore agent** (quick):
+   - Check `/scratchpads/INDEX.md` for related prior work (read full scratchpad only if directly relevant)
+   - Search for similar patterns in source code
 3. Break into tasks with **TodoWrite**
 4. Create scratchpad: `/scratchpads/issue-{number}-{short-name}.md` with issue link + tasks
+5. Update index: `echo "| #{number} | {Description} |" >> /scratchpads/INDEX.md`
 
 ## 3. CREATE
 
@@ -36,10 +39,10 @@ Analyze and fix GitHub issue: $ARGUMENTS
 3. Format/lint: `poetry run ruff format src/ tests/ && poetry run ruff check src/ tests/ --fix`
 4. Type check: `poetry run mypy src/`
 5. All functions need type annotations
-6. Launch **test-coverage-reviewer agent**
 
-## 5. VERIFY & PUSH
+## 5. PUSH & PR
 
-1. Launch **code-quality-reviewer agent**
-2. Push: `git push -u origin {branch}`
-3. Create PR: `gh pr create` with title `{feat|fix}: LIR-N description`, body includes `Closes #{github_issue_number}`
+1. Push: `git push -u origin {branch}`
+2. Create PR: `gh pr create` with title `{feat|fix}: LIR-N description`, body includes `Closes #{github_issue_number}`
+
+Note: Code review happens via `/review-pr` after PR creation.

--- a/scratchpads/INDEX.md
+++ b/scratchpads/INDEX.md
@@ -1,0 +1,54 @@
+# Scratchpad Index
+
+Quick reference for prior implementation work. Read full scratchpad only if directly relevant.
+
+| GitHub # | Description |
+|----------|-------------|
+| #4 | Project Scaffolding |
+| #5 | Card Deck Implementation |
+| #6 | Multi Deck Shoe |
+| #7 | Five Card Hand Evaluation |
+| #8 | Three Card Hand Evaluation |
+| #9 | Paytable Configuration |
+| #10 | Hand Analysis Utilities |
+| #11 | Yaml Configuration |
+| #12 | Hand State Machine |
+| #13 | Basic Strategy |
+| #14 | Baseline Strategies |
+| #15 | Custom Strategy |
+| #16 | Game Engine |
+| #17 | Bonus Strategies |
+| #18 | Bankroll Tracker |
+| #19 | Flat Betting System |
+| #20 | Progressive Betting |
+| #21 | Session State Management |
+| #22 | Session Result Data Structures |
+| #23 | Simulation Controller |
+| #24 | Parallel Execution |
+| #25 | Simulation Results Aggregation |
+| #26 | Statistical Validation |
+| #27 | Rng Quality Seeding |
+| #28 | Core Statistics |
+| #29 | Strategy Comparison |
+| #30 | Csv Export |
+| #31 | Json Export |
+| #32 | Session Histogram |
+| #33 | Bankroll Trajectory |
+| #34 | Cli Entry Point |
+| #35 | Console Output Formatting |
+| #36 | Sample Configurations |
+| #37 | E2E Integration Tests |
+| #38 | Performance Benchmarking |
+| #40 | Streak Based Bonus |
+| #41 | Risk Of Ruin |
+| #42 | Html Report Generation |
+| #71 | Dealer Discard |
+| #72 | Table Abstraction |
+| #73 | Table Session |
+| #74 | Chair Position Analytics |
+| #81 | Table Integration Tests |
+| #82 | Extract Hand Processing |
+| #98 | Controller Factory Tests |
+| #99 | Controller Error Tests |
+| #100 | Test Quality Improvements |
+| #106 | Rng Isolation Hand Testing |


### PR DESCRIPTION
## Summary

- Add `scratchpads/INDEX.md` as lightweight reference (~55 lines vs ~4,168 lines in full scratchpads)
- Change Explore agent thoroughness from "medium" to "quick"
- Direct Explore to check INDEX.md instead of scanning all scratchpads
- Add step to maintain index when creating new scratchpads
- Remove redundant review agents from /issue (deferred to /review-pr command)

## Token Savings Estimate

| Optimization | Estimated Savings |
|--------------|-------------------|
| Index vs full scratchpads | ~4,000 lines (~98%) |
| "quick" vs "medium" Explore | ~30-50% of Explore tokens |
| Removed 2 review agents | ~80k tokens |

## Test Plan

- [ ] Run `/issue` on next feature and compare token usage
- [ ] Verify INDEX.md is updated after scratchpad creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)